### PR TITLE
CDPD-54370: use LeaseRecoverable and SafeMode introduced in hadoop-co…

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/FSUtils.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/FSUtils.java
@@ -62,6 +62,8 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathFilter;
+import org.apache.hadoop.fs.SafeMode;
+import org.apache.hadoop.fs.SafeModeAction;
 import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.hbase.ClusterId;
@@ -81,9 +83,12 @@ import org.apache.hadoop.hdfs.DFSClient;
 import org.apache.hadoop.hdfs.DFSHedgedReadMetrics;
 import org.apache.hadoop.hdfs.DFSUtil;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
+<<<<<<< HEAD
 import org.apache.hadoop.hdfs.client.HdfsDataInputStream;
 import org.apache.hadoop.hdfs.protocol.DatanodeInfo;
 import org.apache.hadoop.hdfs.protocol.LocatedBlock;
+=======
+>>>>>>> 2d941f42699 (CDPD-54370: use LeaseRecoverable and SafeMode introduced in hadoop-common)
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.ipc.RemoteException;
 import org.apache.hadoop.util.StringUtils;
@@ -244,12 +249,22 @@ public final class FSUtils {
   }
 
   /**
+<<<<<<< HEAD
    * Inquire the Active NameNode's safe mode status.
    * @param dfs A DistributedFileSystem object representing the underlying HDFS.
    * @return whether we're in safe mode
    */
   private static boolean isInSafeMode(DistributedFileSystem dfs) throws IOException {
     return dfs.setSafeMode(SAFEMODE_GET, true);
+=======
+   * We don't need the reflection anymore because we don't build with hadoop-1.x
+   * @param safeModeFs the filesystem that implemented safe mode
+   * @return true is in safe mode, false otherwise
+   * @throws IOException any exception when calling setSafeMode
+   */
+  private static boolean isInSafeMode(SafeMode safeModeFs) throws IOException {
+    return safeModeFs.setSafeMode(SafeModeAction.GET);
+>>>>>>> 2d941f42699 (CDPD-54370: use LeaseRecoverable and SafeMode introduced in hadoop-common)
   }
 
   /**
@@ -258,8 +273,8 @@ public final class FSUtils {
   public static void checkDfsSafeMode(final Configuration conf) throws IOException {
     boolean isInSafeMode = false;
     FileSystem fs = FileSystem.get(conf);
-    if (fs instanceof DistributedFileSystem) {
-      DistributedFileSystem dfs = (DistributedFileSystem) fs;
+    if (fs instanceof SafeMode) {
+      SafeMode dfs = (SafeMode) fs;
       isInSafeMode = isInSafeMode(dfs);
     }
     if (isInSafeMode) {
@@ -635,8 +650,8 @@ public final class FSUtils {
    */
   public static void waitOnSafeMode(final Configuration conf, final long wait) throws IOException {
     FileSystem fs = FileSystem.get(conf);
-    if (!(fs instanceof DistributedFileSystem)) return;
-    DistributedFileSystem dfs = (DistributedFileSystem) fs;
+    if (!(fs instanceof SafeMode)) return;
+    SafeMode dfs = (SafeMode) fs;
     // Make sure dfs is not in safe mode
     while (isInSafeMode(dfs)) {
       LOG.info("Waiting for dfs to exit safe mode...");

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestSafemodeBringsDownMaster.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestSafemodeBringsDownMaster.java
@@ -21,6 +21,8 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.SafeMode;
+import org.apache.hadoop.fs.SafeModeAction;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
 import org.apache.hadoop.hbase.TableName;
@@ -33,9 +35,7 @@ import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.hadoop.hbase.util.JVMClusterUtil;
-import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
-import org.apache.hadoop.hdfs.protocol.HdfsConstants;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -104,8 +104,8 @@ public class TestSafemodeBringsDownMaster {
     RegionInfo[] regions = MasterProcedureTestingUtility.createTable(getMasterProcedureExecutor(),
       tableName, splitKeys, "f1", "f2");
     MiniDFSCluster dfsCluster = UTIL.getDFSCluster();
-    DistributedFileSystem dfs = (DistributedFileSystem) dfsCluster.getFileSystem();
-    dfs.setSafeMode(HdfsConstants.SafeModeAction.SAFEMODE_ENTER);
+    SafeMode dfs = dfsCluster.getFileSystem();
+    dfs.setSafeMode(SafeModeAction.ENTER);
     final long timeOut = 180000;
     long startTime = EnvironmentEdgeManager.currentTime();
     int index = -1;
@@ -125,6 +125,6 @@ public class TestSafemodeBringsDownMaster {
         return threads == null || threads.isEmpty();
       }
     });
-    dfs.setSafeMode(HdfsConstants.SafeModeAction.SAFEMODE_LEAVE);
+    dfs.setSafeMode(SafeModeAction.LEAVE);
   }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/wal/TestWALFactory.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/wal/TestWALFactory.java
@@ -42,6 +42,7 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.SafeModeAction;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.Coprocessor;
@@ -372,7 +373,7 @@ public class TestWALFactory {
     // Stop the cluster. (ensure restart since we're sharing MiniDFSCluster)
     try {
       DistributedFileSystem dfs = cluster.getFileSystem();
-      dfs.setSafeMode(HdfsConstants.SafeModeAction.SAFEMODE_ENTER);
+      dfs.setSafeMode(SafeModeAction.ENTER);
       TEST_UTIL.shutdownMiniDFSCluster();
       try {
         // wal.writer.close() will throw an exception,


### PR DESCRIPTION
…mmon

- no new unit test, but we can reuse the existing one before we see any error/bug

Change-Id: I2c18bc72e65f8f671a9a3374c5f7990074ab3c97 (cherry picked from commit c2f5b8d593052c80b3e3df9c1bf95a79d9f806bb)

 Conflicts:
	hbase-server/src/main/java/org/apache/hadoop/hbase/util/FSUtils.java

Change-Id: I9f6ff7ed2eef465862e892016822e92083dc9e27 (cherry picked from commit cea8e27c7c0ed9a7db7ef7c4eb6da67996a45035) (cherry picked from commit 2d941f4269931c0e33095a312dfd58f1d62788cf)